### PR TITLE
Make Image Zoom work with Starlight Blog

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -164,6 +164,9 @@ export default defineConfig({
           label: "Italiano",
         },
       },
+      components: {
+          MarkdownContent: "./src/components/MarkdownContent.astro",
+      },
     }),
     tailwind({
       // Disable the default base styles:

--- a/src/components/MarkdownContent.astro
+++ b/src/components/MarkdownContent.astro
@@ -1,0 +1,8 @@
+---
+import type { Props } from '@astrojs/starlight/props'
+import Default from "starlight-blog/overrides/MarkdownContent.astro"
+import ImageZoom from 'starlight-image-zoom/components/ImageZoom.astro'
+---
+
+<ImageZoom />
+<Default {...Astro.props}><slot /></Default>


### PR DESCRIPTION
Hello!

I'm not sure if it is intended or not, but I think that the Starlight Blog will not be able to override the MarkdownContent.astro page because it is already overridden by the Image Zoom plugin. 

In this PR I have created a potential fix for this, feel free to try it out!

Have a nice day, bye!